### PR TITLE
Simplify the type of Derivation

### DIFF
--- a/dhall/derivation.dhall
+++ b/dhall/derivation.dhall
@@ -3,12 +3,11 @@
           → ./types/Derivation.dhall
         =   λ(mk-args : (./types/Derivation.dhall → Text) → ./types/Args.dhall)
           → λ(Derivation : Type)
-          → λ(store-path : Derivation → Text)
-          → λ(Mk-Derivation : ./types/Args.dhall → Derivation)
+          → λ(Mk-Derivation : ./types/Args.dhall → Text)
           → Mk-Derivation
             ( mk-args
               (   λ(derivation : ./types/Derivation.dhall)
-                → store-path (derivation Derivation store-path Mk-Derivation)
+                → derivation Derivation Mk-Derivation
               )
             )
 

--- a/dhall/types/Derivation.dhall
+++ b/dhall/types/Derivation.dhall
@@ -1,4 +1,1 @@
-  ∀(Derivation : Type)
-→ ∀(store-path : Derivation → Text)
-→ ∀(Mk-Derivation : ./Args.dhall → Derivation)
-→ Derivation
+∀(Derivation : Type) → ∀(Mk-Derivation : ./Args.dhall → Text) → Text

--- a/nix/eval.nix
+++ b/nix/eval.nix
@@ -1,7 +1,6 @@
 x:
 x
   null
-  ( x: "${x}" )
   ( args:
     derivation (
     ( builtins.mapAttrs


### PR DESCRIPTION
The previous type of Derivation was

      ∀(Derivation : Type)
    → ∀(store-path : Derivation → Text)
    → ∀(Mk-Derivation : args → Derivation)
    → Derivation

But @Gabriel439 points out that this can be simpler. If we have (only)
store-path : Derivation → Text and Mk-Derivation : args → Derivation,
then we might as well just use the composition of these. Thus the new
type is

      ∀(Derivation : Type)
    → ∀(Mk-Derivation : args → Text)
    → Text

We may return to the old representatin if we need more operations on a
Derivation, but for now this is simpler.