### PR TITLE
Remove the (Derivation : Type) argument from Derivation

### DIFF
--- a/dhall/derivation.dhall
+++ b/dhall/derivation.dhall
@@ -2,12 +2,11 @@
         :   ((./types/Derivation.dhall → Text) → ./types/Args.dhall)
           → ./types/Derivation.dhall
         =   λ(mk-args : (./types/Derivation.dhall → Text) → ./types/Args.dhall)
-          → λ(Derivation : Type)
           → λ(Mk-Derivation : ./types/Args.dhall → Text)
           → Mk-Derivation
             ( mk-args
               (   λ(derivation : ./types/Derivation.dhall)
-                → derivation Derivation Mk-Derivation
+                → derivation Mk-Derivation
               )
             )
 

--- a/dhall/types/Derivation.dhall
+++ b/dhall/types/Derivation.dhall
@@ -1,1 +1,1 @@
-∀(Derivation : Type) → ∀(Mk-Derivation : ./Args.dhall → Text) → Text
+∀(Mk-Derivation : ./Args.dhall → Text) → Text

--- a/nix/eval.nix
+++ b/nix/eval.nix
@@ -1,7 +1,5 @@
 x:
-x
-  null
-  ( args:
+x ( args:
     derivation (
     ( builtins.mapAttrs
         ( _: v:


### PR DESCRIPTION
@Gabriel439 rightly points out that after #3 there's actually no need
for the Derivation : Type argument at all (and indeed, nothing was
actulaly using this type).